### PR TITLE
Add more feature and remove unused code

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Opmodes/Main.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Opmodes/Main.java
@@ -7,13 +7,24 @@ import org.firstinspires.ftc.teamcode.Subsystems.Drivebase;
 
 @TeleOp(name = "Main")
 public class Main extends LinearOpMode {
-    private Drivebase drivetrain;
+    private Drivebase drive;
     public void runOpMode() {
-        drivetrain = new Drivebase(hardwareMap);
+        drive = new Drivebase(hardwareMap);
 
         waitForStart();
         while (opModeIsActive()) {
-            drivetrain.setDrivePower(-gamepad1.left_stick_y,-gamepad1.right_stick_y);
+            double y = -gamepad1.left_stick_y;
+            double rx = gamepad1.right_stick_x;
+            double max = Math.abs(y) + Math.abs(rx);
+            max = Math.max(max, 1);
+            double pLeft = (y + rx) / max;
+            double pRight = (y - rx) / max;
+            drive.setDrivePower(pLeft, pRight);
+            if(gamepad1.circle) {
+                drive.setClimber(0.7);
+            } else if(gamepad1.square) {
+                drive.setClimber(-0.7);
+            }
         }
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Subsystems/Drivebase.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Subsystems/Drivebase.java
@@ -1,23 +1,24 @@
 package org.firstinspires.ftc.teamcode.Subsystems;
 
+import com.qualcomm.robotcore.hardware.DcMotor;
 import com.qualcomm.robotcore.hardware.DcMotorEx;
 import com.qualcomm.robotcore.hardware.DcMotorSimple;
 import com.qualcomm.robotcore.hardware.HardwareMap;
 
 public class Drivebase {
-    private DcMotorEx left, right;
+    private DcMotor left, right, climber;
     public Drivebase(HardwareMap hardwareMap) {
-        left = hardwareMap.get(DcMotorEx.class,"leftDrive");
-        right = hardwareMap.get(DcMotorEx.class, "rightDrive");
-
-        left.setDirection(DcMotorSimple.Direction.FORWARD);
-        right.setDirection(DcMotorSimple.Direction.REVERSE);
-
-        left.setZeroPowerBehavior(DcMotorEx.ZeroPowerBehavior.BRAKE);
-        right.setZeroPowerBehavior(DcMotorEx.ZeroPowerBehavior.BRAKE);
+        left = hardwareMap.get(DcMotor.class,"leftDrive");
+        right = hardwareMap.get(DcMotor.class, "rightDrive");
+        climber = hardwareMap.get(DcMotor.class, "sliderHexCore");
+        climber.setZeroPowerBehavior(DcMotor.ZeroPowerBehavior.BRAKE);
     }
     public void setDrivePower(double leftPw, double rightPw) {
         left.setPower(leftPw);
         right.setPower(rightPw);
+    }
+
+    public void setClimber(double Power) {
+        climber.setPower(Power);
     }
 }


### PR DESCRIPTION
Remove ```setZeroPowerBehavior``` for the left and right motors because obviously, we don't need to break every time we stop.
The left joystick is for vertical movement and the right one is for steering 
No need to set the right motor to be ```FORWARD```
Update Climber code